### PR TITLE
feat: create-swagger-openapi-request-permission-configuration

### DIFF
--- a/infrastructure/stacks/apigateway_stack.py
+++ b/infrastructure/stacks/apigateway_stack.py
@@ -140,6 +140,9 @@ class APIGatewayStack(Stack):
         # GET /docs - Swagger UI documentation
         self.docs_resource = self.api.root.add_resource("docs")
 
+        # GET /openapi.json - OpenAPI specification
+        self.openapi_resource = self.api.root.add_resource("openapi.json")
+
     def add_lambda_integration(
         self,
         lambda_function: lambda_.Function,
@@ -163,6 +166,7 @@ class APIGatewayStack(Stack):
         self.batch_resource.add_method("POST", lambda_integration)
         self.health_resource.add_method("GET", lambda_integration)
         self.docs_resource.add_method("GET", lambda_integration)
+        self.openapi_resource.add_method("GET", lambda_integration)
 
         # Note: LambdaIntegration automatically grants necessary permissions
         # Manual add_permission is not required and causes circular dependency

--- a/lambda_function/lambda_function.py
+++ b/lambda_function/lambda_function.py
@@ -68,6 +68,13 @@ app.add_middleware(
 )
 
 
+# Custom OpenAPI endpoint without API key requirement
+@app.get("/openapi.json", include_in_schema=False)
+async def custom_openapi():
+    """Return OpenAPI specification without requiring API key."""
+    return app.openapi()
+
+
 # Health check endpoint
 @app.get("/health")
 async def health_check(api_key: str = Security(get_api_key)):


### PR DESCRIPTION
## 작업 내용
- swagger UI 생성시 openapi.json 파일 접근을 위한 apigateway 및 fastapi 람다의 처리 로직을 추가 합니다.

## 체크리스트

- [x] 테스트 통과 (`uv run pytest`)
- [x] 코드 포맷팅 적용 (`uv run black lambda_function/ infrastructure/`)
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 (필요시)

## 테스트 방법 및 결과
- 로컬 테스트 완료 되어 실제 배포 후 육안 접근 가능 확인 예정 
