### PR TITLE
fix: update-openapi-json-file-access-url-prefix

### DIFF
--- a/lambda_function/lambda_function.py
+++ b/lambda_function/lambda_function.py
@@ -21,8 +21,11 @@ from models import (
 )
 
 # Simple configuration
-ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
+ENVIRONMENT = os.getenv("ENV", "dev")
+
+# Set stage prefix based on environment
+STAGE_PREFIX = f"/{ENVIRONMENT}"
+
 MAX_BATCH_CITIES = 10
 
 # Configure logging
@@ -56,7 +59,7 @@ app = FastAPI(
     description="Serverless weather API service",
     version="1.0.0",
     docs_url="/docs",
-    openapi_url="/openapi.json",  # Required for Lambda environment
+    openapi_url=f"{STAGE_PREFIX}/openapi.json",  # Dynamic stage prefix
     redoc_url=None,
 )
 

--- a/tests/lambda_function/test_lambda_function.py
+++ b/tests/lambda_function/test_lambda_function.py
@@ -596,7 +596,7 @@ class TestDocumentationEndpoints:
 
     def test_openapi_schema_accessible(self, client):
         """Test that OpenAPI schema is accessible without API key."""
-        response = client.get("/openapi.json")
+        response = client.get("/dev/openapi.json")
         assert response.status_code == 200
         assert "application/json" in response.headers["content-type"]
 
@@ -608,7 +608,7 @@ class TestDocumentationEndpoints:
 
     def test_openapi_schema_contains_security(self, client):
         """Test that OpenAPI schema includes security schemes."""
-        response = client.get("/openapi.json")
+        response = client.get("/dev/openapi.json")
         schema = response.json()
 
         # Check security schemes are defined
@@ -627,7 +627,7 @@ class TestDocumentationEndpoints:
 
     def test_openapi_schema_contains_endpoints(self, client):
         """Test that OpenAPI schema includes all API endpoints."""
-        response = client.get("/openapi.json")
+        response = client.get("/dev/openapi.json")
         schema = response.json()
 
         assert "paths" in schema


### PR DESCRIPTION
## 작업 내용
- 람다 swagger url에서 openapi.json 호출시 스테이지 별 url이 프리픽스로 붙지 않는 문제를 해결 하고자함

## 체크리스트

- [x] 테스트 통과 (`uv run pytest`)
- [x] 코드 포맷팅 적용 (`uv run black lambda_function/ infrastructure/`)
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 (필요시)

## 테스트 방법 및 결과
- 실제 배포를 통해서 정상 동작 상태 확인 예정 
