### PR TITLE
fix: resolve-additional-fastapi-openapi-path-configuration-errors

### DIFF
--- a/lambda_function/lambda_function.py
+++ b/lambda_function/lambda_function.py
@@ -59,8 +59,9 @@ app = FastAPI(
     description="Serverless weather API service",
     version="1.0.0",
     docs_url="/docs",
-    openapi_url=f"{STAGE_PREFIX}/openapi.json",  # Points to custom endpoint
+    openapi_url="/openapi.json",  # Dynamic stage prefix
     redoc_url=None,
+    root_path=STAGE_PREFIX,
 )
 
 # Configure CORS
@@ -71,13 +72,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-# Custom OpenAPI endpoint with stage prefix
-@app.get(f"{STAGE_PREFIX}/openapi.json", include_in_schema=False)
-async def custom_openapi():
-    """Return OpenAPI specification with stage prefix support."""
-    return app.openapi()
 
 
 # Health check endpoint


### PR DESCRIPTION
## 작업 내용
- fast api의 Swagger 문서 및 openapi 설정관련하여 중복되는 설정을 수정합니다.

## 체크리스트

- [x] 테스트 통과 (`uv run pytest`)
- [x] 코드 포맷팅 적용 (`uv run black lambda_function/ infrastructure/`)
- [x] 로컬 테스트 완료
- [ ] 문서 업데이트 (필요시)

## 테스트 방법 및 결과
- 웹 콘솔 환경에서 배포 후 동작 확인함 배포 후 추가 확인 예정
